### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,12 +20,7 @@
     "ajax",
     "retry"
   ],
-  "license": [
-    {
-      "type": "MIT",
-      "url": "https://github.com/gdibble/ajaxretry/blob/master/LICENSE"
-    }
-  ],
+  "license": "MIT",
   "main": "ajaxretry.min.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
